### PR TITLE
Extend image button to insert external images

### DIFF
--- a/core/ui/EditorToolbar/picture-dropdown.tid
+++ b/core/ui/EditorToolbar/picture-dropdown.tid
@@ -4,8 +4,44 @@ title: $:/core/ui/EditorToolbar/picture-dropdown
 [img[$(imageTitle)$]]
 \end
 
+\define insert-external-image()
+<$set name="imageTitle" value={{$(pictureTiddler)$}}>
+<$button class="tc-btn-invisible" style="width: auto; display: inline-block; background-colour: inherit;">
+<$action-sendmessage $message="tm-edit-text-operation" $param="replace-selection" text=<<insert-external-image>>
+/>
+{{$:/core/images/chevron-right}}
+<$action-deletetiddler
+	$tiddler=<<dropdown-state>>
+/>
+
+<$action-deletetiddler
+	$tiddler=<<pictureTiddler>>
+/>
+</$button>
+</$set>
+\end
+
+\define body(config-title)
+''<<lingo Hint>>''
+
+<$vars pictureTiddler="""$config-title$/search""" imageTitle={{$(pictureTiddler)$}} >
+
+<$edit-text tiddler=<<pictureTiddler>> type="search" tag="input" focus="true" placeholder={{$:/language/Buttons/Picture/Hint}} default=""/>
+<$reveal tag="span" state=<<pictureTiddler>> type="nomatch" text="">
+<<external-image>>
+<$button class="tc-btn-invisible" style="width: auto; display: inline-block; background-colour: inherit;">
+<$action-setfield $tiddler=<<pictureTiddler>> text="" />
+{{$:/core/images/close-button}}
+</$button>
+</$reveal>
+
+</$vars>
+
+\end
+
 ''{{$:/language/Buttons/Picture/Hint}}''
 
+<$macrocall $name="body" config-title=<<qualify "$:/state/Picture/">>/>
 <$macrocall $name="image-picker" actions="""
 
 <$action-sendmessage

--- a/core/ui/EditorToolbar/picture-dropdown.tid
+++ b/core/ui/EditorToolbar/picture-dropdown.tid
@@ -1,57 +1,59 @@
-title: $:/core/ui/EditorToolbar/picture-dropdown
+\define preview-state() $(state)$/preview
 
 \define replacement-text()
 [img[$(imageTitle)$]]
 \end
 
-\define insert-external-image()
-<$set name="imageTitle" value={{$(pictureTiddler)$}}>
-<$button class="tc-btn-invisible" style="width: auto; display: inline-block; background-colour: inherit;">
-<$action-sendmessage $message="tm-edit-text-operation" $param="replace-selection" text=<<insert-external-image>>
-/>
-{{$:/core/images/chevron-right}}
-<$action-deletetiddler
-	$tiddler=<<dropdown-state>>
-/>
-
-<$action-deletetiddler
-	$tiddler=<<pictureTiddler>>
-/>
-</$button>
+\define insert-img-actions()
+<$set name="imageTitle" value=<<imageTitle>> emptyValue={{$(state)$}}>
+<$action-sendmessage $message="tm-edit-text-operation" $param="replace-selection" text=<<replacement-text>> />
+<$action-deletetiddler $tiddler=<<dropdown-state>> />
+<$action-deletetiddler $tiddler=<<state>> />
 </$set>
 \end
 
-\define body(config-title)
+\define body(state)
 ''<<lingo Hint>>''
 
-<$vars pictureTiddler="""$config-title$/search""" imageTitle={{$(pictureTiddler)$}} >
-
-<$edit-text tiddler=<<pictureTiddler>> type="search" tag="input" focus="true" placeholder={{$:/language/Buttons/Picture/Hint}} default=""/>
-<$reveal tag="span" state=<<pictureTiddler>> type="nomatch" text="">
-<<external-image>>
-<$button class="tc-btn-invisible" style="width: auto; display: inline-block; background-colour: inherit;">
-<$action-setfield $tiddler=<<pictureTiddler>> text="" />
+<$keyboard key="ENTER" actions=<<insert-img-actions>>>
+<$edit-text tiddler=<<state>> type="search" tag="input" focus="true" placeholder={{$:/language/Buttons/Picture/Hint}} default=""/>
+<$reveal tag="span" state=<<state>> type="nomatch" text="">
+<$button class="tc-btn-invisible" actions=<<insert-img-actions>>>
+{{$:/core/images/chevron-right}}
+</$button>
+<$button class="tc-btn-invisible">
+<$action-deletetiddler $tiddler=<<state>> />
 {{$:/core/images/close-button}}
 </$button>
+<$reveal state=<<preview-state>> type="match" text="">
+<$button  class="tc-btn-invisible">
+<$action-setfield $tiddler=<<preview-state>> text="display"/>
+{{$:/core/images/preview-closed}}
+</$button>
 </$reveal>
-
+<$reveal state=<<preview-state>> type="nomatch" text="">
+<$button  class="tc-btn-invisible tc-selected">
+<$action-deletetiddler $tiddler=<<preview-state>>/>
+{{$:/core/images/preview-open}}
+</$button>
+<$vars imageTitle={{$(state)$}}>
+<div class="tc-image-chooser">
+<$button tag="a" tooltip=<<imageTitle>> actions=<<insert-img-actions>>>
+<<replacement-text>>
+</$button>
+</div>
 </$vars>
+</$reveal>
+</$reveal>
+</$keyboard>
 
+<$vars imageTitle={{$(state)$}}>
+<$macrocall $name="image-picker" actions=<<insert-img-actions>> />
+</$vars>
 \end
 
 ''{{$:/language/Buttons/Picture/Hint}}''
 
-<$macrocall $name="body" config-title=<<qualify "$:/state/Picture/">>/>
-<$macrocall $name="image-picker" actions="""
-
-<$action-sendmessage
-	$message="tm-edit-text-operation"
-	$param="replace-selection"
-	text=<<replacement-text>>
-/>
-
-<$action-deletetiddler
-	$tiddler=<<dropdown-state>>
-/>
-
-"""/>
+<$vars state=<<qualify "$:/state/EditorToolbar/Picture">>>
+<<body>>
+</$vars>

--- a/core/wiki/macros/image-picker.tid
+++ b/core/wiki/macros/image-picker.tid
@@ -1,26 +1,32 @@
-title: $:/core/macros/image-picker
-tags: $:/tags/Macro
-
-\define image-picker-inner(actions)
+\define image-picker-thumbnail(actions)
 <$button tag="a" tooltip="""$(imageTitle)$""">
-
 $actions$
-
 <$transclude tiddler=<<imageTitle>>/>
-
 </$button>
 \end
 
-\define image-picker(actions,subfilter:"")
-<div class="tc-image-chooser">
-
-<$list filter="[all[shadows+tiddlers]is[image]$subfilter$!has[draft.of]] -[type[application/pdf]] +[sort[title]]" variable="imageTitle">
-
-<$macrocall $name="image-picker-inner" actions="""$actions$"""/>
-
+\define image-picker-list(filter,actions)
+<$list filter="""$filter$""" variable="imageTitle">
+<$macrocall $name="image-picker-thumbnail" actions="""$actions$"""/>
 </$list>
-
-</div>
-
 \end
 
+\define image-picker(actions,filter:"[all[shadows+tiddlers]is[image]] -[type[application/pdf]] +[!has[draft.of]search:title<imageTitle>sort[title]]")
+<div class="tc-image-chooser">
+<$vars state-system=<<qualify "$:/state/image-picker/system">>>
+<$checkbox tiddler=<<state-system>> field="text" checked="show" unchecked="hide" default="hide">
+{{$:/language/SystemTiddlers/Include/Prompt}}
+</$checkbox>
+<$reveal state=<<state-system>> type="match" text="hide" default="hide" tag="div">
+<$macrocall $name="image-picker-list" filter="""$filter$ +[!is[system]]""" actions="""$actions$"""/>
+</$reveal>
+<$reveal state=<<state-system>> type="nomatch" text="hide" default="hide" tag="div">
+<$macrocall $name="image-picker-list" filter="""$filter$""" actions="""$actions$"""/>
+</$reveal>
+</$vars>
+</div>
+\end
+
+\define image-picker-include-tagged-images(actions)
+<$macrocall $name="image-picker" filter="[all[shadows+tiddlers]is[image]] [all[shadows+tiddlers]tag[$:/tags/Image]] -[type[application/pdf]] +[!has[draft.of]search:title<imageTitle>sort[title]]" actions="""$actions$"""/>
+\end

--- a/themes/tiddlywiki/vanilla/base.tid
+++ b/themes/tiddlywiki/vanilla/base.tid
@@ -2177,3 +2177,29 @@ body.tc-dirty span.tc-dirty-indicator, body.tc-dirty span.tc-dirty-indicator svg
 	background: #f00;
 	color: #fff;
 }
+
+.tc-editor-toolbar .tc-drop-down .tc-btn-invisible {
+
+	background:none;
+	border:0; padding:0;
+	display:inline-block;
+	width:auto;
+
+}
+
+.tc-editor-toolbar .tc-drop-down .tc-btn-invisible svg {
+	fill: #cccccc;
+
+}
+
+.tc-editor-toolbar .tc-drop-down .tc-btn-invisible.tc-selected svg {
+
+fill: #444444;
+
+}
+
+.tc-editor-toolbar .tc-drop-down .tc-btn-invisible:hover svg {
+
+fill: #888888;
+
+}


### PR DESCRIPTION
This basically reuses mostly code from https://github.com/Jermolene/TiddlyWiki5/blob/master/core/ui/EditorToolbar/link-dropdown.tid

It adds an edit text box with an insert button that allows inserting external images in wikitext through their URL.

Please check code sanity, it may be over complicated or have redundant parts, I am not at all a coder. It may also need new localized language strings

Ideally this text box would also allow filtering or searching for internal image tiddlers displayed in the list bellow, just like in the links button dropdown currently, but that is way above my skill level.
It should also commit changes when pressing enter key

Discussion here https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/tiddlywiki/7LfTfO7oC9U/lT_P5mi4EQAJ